### PR TITLE
[CHORE]Update build configuration and add Maven Central workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,56 @@
+name: Publish to Maven Central (manual or v* tags on main)
+
+on:
+  # 수동 실행 허용
+  workflow_dispatch: {}
+  # v* 태그 푸시 시 자동 실행 (예: v0.1.0)
+  push:
+    tags:
+      - 'v*'
+
+concurrency:
+  group: release-central
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout (full history)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # 태그가 main 히스토리 위인지 확인 (아니면 중립 스킵)
+      - name: Ensure tag commit is on main history
+        if: ${{ github.event_name == 'push' }}
+        shell: bash
+        run: |
+          TAG_SHA="${GITHUB_SHA}"
+          git fetch origin main --quiet
+          if git merge-base --is-ancestor origin/main "$TAG_SHA"; then
+            echo "✅ Tag commit is on main history."
+          else
+            echo "⏭️ Tag commit is NOT on main. Skipping."
+            exit 78 # neutral
+          fi
+
+      - name: Set up Temurin JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: gradle
+
+      # (선택) Gradle Wrapper 검증
+      # - uses: gradle/actions/wrapper-validation@v3
+
+      - name: Publish (upload + validate only; portal Publish is manual)
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.CENTRAL_TOKEN_USER }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.CENTRAL_TOKEN_PASS }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_PRIVATE_KEY_ARMOR }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_PASSPHRASE }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.GPG_KEY_ID }}
+        run: ./gradlew publishToMavenCentral --no-daemon

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,0 +1,44 @@
+name: Publish SNAPSHOT (develop)
+
+on:
+  push:
+    branches: [develop]
+
+concurrency:
+  group: snapshot-central
+  cancel-in-progress: true
+
+jobs:
+  snapshot:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Temurin JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: gradle
+
+      # 버전이 *-SNAPSHOT 인지 방어 (예: 0.1.1-SNAPSHOT)
+      - name: Guard: version must be *-SNAPSHOT
+        shell: bash
+        run: |
+          VER=$(./gradlew -q properties | awk -F': ' '/^version:/ {print $2}')
+          echo "Detected version: $VER"
+          [[ "$VER" == *-SNAPSHOT ]] || { echo "Version is not SNAPSHOT. Skipping."; exit 78; }
+
+      # (선택) Gradle Wrapper 검증
+      # - uses: gradle/actions/wrapper-validation@v3
+
+      - name: Publish SNAPSHOT (no manual portal publish needed)
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.CENTRAL_TOKEN_USER }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.CENTRAL_TOKEN_PASS }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_PRIVATE_KEY_ARMOR }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_PASSPHRASE }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.GPG_KEY_ID }}
+        run: ./gradlew publishToMavenCentral --no-daemon

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -1,20 +1,22 @@
 plugins {
 	id 'java-library'
-	id 'maven-publish'
+	// Maven Central (Central Portal) 배포용 플러그인 — 자동 퍼블리시는 안 켬
+	id 'com.vanniktech.maven.publish' version '0.34.0'
+
+	// (선택) 사용자 프로젝트에 Boot를 쓰더라도, 여긴 라이브러리 모듈로만 빌드됨
 	id 'org.springframework.boot' version '3.5.7' apply false
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
-group = 'kr.co'
-version = '0.0.1-SNAPSHOT'
+group = 'io.github.whitesnakegang'   // ← 실제 groupId 반영
+version = '0.1.0-SNAPSHOT'                    // ← 스냅샷이면 0.1.1-SNAPSHOT 등으로
+
 description = 'Open Source Project'
 
 java {
 	toolchain {
 		languageVersion = JavaLanguageVersion.of(17)
 	}
-	withSourcesJar()  // 소스 JAR 생성
-	withJavadocJar()  // Javadoc JAR 생성
 }
 
 configurations {
@@ -29,66 +31,104 @@ repositories {
 
 dependencyManagement {
 	imports {
+		// Boot BOM으로 starter, jackson 등 버전 자동 관리
 		mavenBom org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES
+		// 또는 명시하고 싶으면: mavenBom "org.springframework.boot:spring-boot-dependencies:3.5.7"
 	}
 }
 
 dependencies {
-	implementation("org.springdoc:springdoc-openapi-starter-webmvc-api:2.8.13")
-	// Spring Boot (사용자 프로젝트의 버전에 기생)
-	compileOnly 'org.springframework.boot:spring-boot-starter-web'
+	implementation "org.springdoc:springdoc-openapi-starter-webmvc-api:2.8.13"
 
-	// YAML processing
-	implementation 'org.yaml:snakeyaml:2.2'
+	// 사용자 앱 쪽 Boot 버전에 '기생'하고 싶다면 compileOnly 유지 (라이브러리 자체는 Boot에 종속 X)
+	compileOnly "org.springframework.boot:spring-boot-starter-web"
 
-	// DataFaker for mock data generation
-	implementation 'net.datafaker:datafaker:2.1.0'
+	// YAML
+	implementation "org.yaml:snakeyaml:2.2"
 
-	// Lombok
-	compileOnly 'org.projectlombok:lombok'
-	annotationProcessor 'org.projectlombok:lombok'
+	// DataFaker (중복 제거: 최신 것만 남김)
+	implementation "net.datafaker:datafaker:2.5.2"
 
-	// Testing
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	// XML
+	implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-xml"
 
-	// Data Generator
-	implementation 'net.datafaker:datafaker:2.5.2'
-	// xml formatting
-	implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml'
+	// Lombok (버전 명시)
+	compileOnly "org.projectlombok:lombok:1.18.34"
+	annotationProcessor "org.projectlombok:lombok:1.18.34"
+	testCompileOnly "org.projectlombok:lombok:1.18.34"
+	testAnnotationProcessor "org.projectlombok:lombok:1.18.34"
+
+	// Test
+	testImplementation "org.springframework.boot:spring-boot-starter-test"
+	testRuntimeOnly "org.junit.platform:junit-platform-launcher"
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
 }
 
-tasks.withType(JavaCompile) {
-	options.encoding = 'UTF-8'
-}
-
-tasks.withType(Javadoc) {
+tasks.withType(JavaCompile).configureEach { options.encoding = 'UTF-8' }
+tasks.withType(Javadoc).configureEach {
 	options.encoding = 'UTF-8'
 	options.charSet = 'UTF-8'
 	options.docEncoding = 'UTF-8'
 }
 
-publishing {
-	publications {
-		mavenJava(MavenPublication) {
-			from components.java
+/**
+ * Maven Central(포털) 업로드: 자동 퍼블리시는 사용하지 않음.
+ * - User Token은 gradle.properties 또는 환경변수(ORG_GRADLE_PROJECT_*)로 주입
+ * - 모든 아티팩트는 GPG 서명(플러그인이 처리)
+ */
+mavenPublishing {
+	// Central Portal 사용 (인자 없이 호출하면 Central 경로로 처리됨)
+	publishToMavenCentral()
+	// GPG 서명 (중앙 필수)
+	signAllPublications()
 
-			pom {
-				name = 'Ouroboros'
-				description = 'Open Source Project'
-				url = 'https://github.com/whitesnakegang/ouroboros'
+	// GAV 좌표 — 위의 group/version과 동일. (여기만 써도 되지만 둘 다 맞춰둠)
+	coordinates(
+			"io.github.whitesnakegang", // groupId
+			"ouroboros",                // artifactId
+			version                     // 현재 version 값 사용
+	)
 
-				licenses {
-					license {
-						name = 'The Apache License, Version 2.0'
-						url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-					}
-				}
+	// POM 메타데이터 (중앙 검증 필수 항목)
+	pom {
+		name = "ouroboros"
+		description = "RESTAPI mock/proxy utilities for JVM apps (Java 17+)."
+		inceptionYear = "2025"
+		url = "https://github.com/whitesnakegang/ouroboros"
+
+		licenses {
+			license {
+				name = "The Apache License, Version 2.0"
+				url  = "https://www.apache.org/licenses/LICENSE-2.0.txt"
+				distribution = "repo"
 			}
 		}
+		developers {
+			developer {
+				id  = "whitesnakegang"
+				name= "Whitesnakegang"
+				url = "https://github.com/whitesnakegang"
+			}
+		}
+		scm {
+			url                 = "https://github.com/whitesnakegang/ouroboros"
+			connection          = "scm:git:https://github.com/whitesnakegang/ouroboros.git"
+			developerConnection = "scm:git:ssh://git@github.com/whitesnakegang/ouroboros.git"
+			tag = "HEAD"
+		}
+	}
+}
+
+/**
+ * 로컬 배포(publishToMavenLocal) 시에는 서명 스킵:
+ * - GPG 키/패스프레이즈 없어도 로컬 테스트 가능
+ * - 중앙 배포(publishToMavenCentral) 시에는 정상 서명
+ */
+gradle.taskGraph.whenReady { graph ->
+	if (graph.hasTask(':publishToMavenLocal')) {
+		tasks.matching { it.name.startsWith('sign') }.configureEach { enabled = false }
 	}
 }

--- a/backend/src/main/java/kr/co/ouroboros/core/global/mock/service/SchemaMockBuilder.java
+++ b/backend/src/main/java/kr/co/ouroboros/core/global/mock/service/SchemaMockBuilder.java
@@ -34,6 +34,7 @@ public class SchemaMockBuilder {
      * @param schema the JSON schema map defining the structure
      * @return built mock object (Map for objects, List for arrays, primitives for other types)
      */
+    @SuppressWarnings("unchecked")
     public Object build(Map<String, Object> schema) {
         if (schema == null) return Collections.emptyMap();
 


### PR DESCRIPTION
 ## 📌 Summary
  Maven Central 배포를 위한 빌드 설정 개선 및 GitHub Actions 워크플로우 추가

  ---

  ## ✅ Type of Change
  - [x] 🔧 Chore (build, CI, dependencies, etc.)

  ---

  ## 🧠 Description
  Maven Central에 라이브러리를 배포하기 위해 빌드 설정을 개선하고, 자동 배포를 위한 CI/CD 워크플로우를
  추가했습니다.

  ---

  ## 🔍 Changes
  - [x] Config / Infrastructure
  - [x] Other: GitHub Actions Workflow

  **주요 변경사항:**

  ### 1. Maven 배포 플러그인 변경
  - `maven-publish` → `com.vanniktech.maven.publish` (Maven Central 호환)
  - groupId, artifactId, version, description 등 메타데이터 설정

  ### 2. GitHub Actions 워크플로우 추가
  - **SNAPSHOT 배포**: `develop` 브랜치 푸시 시 자동 배포
  - **릴리즈 배포**: `v*` 태그 생성 시 자동 배포

  ### 3. Gradle 빌드 개선
  - UTF-8 인코딩 강제 설정 (한글 JavaDoc 지원)
  - 로컬 빌드 시 signing 비활성화 (`publishToMavenLocal` 조건부 처리)

  ### 4. 컴파일 경고 수정
  - `SchemaMockBuilder`에 `@SuppressWarnings("unchecked")` 추가

  ---

  ## 🧾 Related Issues
  > N/A

  이렇게 간단하고 명확하게 작성했습니다!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **Chores**
  * Maven Central에 대한 자동화된 배포 워크플로우 추가
  * 프로젝트 그룹 및 버전 좌표 업데이트
  * 빌드 배포 구성 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->