### PR TITLE
[FIX] 명세 작성 시 registry 등록 재개

### DIFF
--- a/backend/src/main/java/kr/co/ouroboros/core/global/mock/registry/MockRegistryBase.java
+++ b/backend/src/main/java/kr/co/ouroboros/core/global/mock/registry/MockRegistryBase.java
@@ -36,5 +36,10 @@ public interface MockRegistryBase<T> {
      */
     Optional<T> find(String key1, String key2);
 
-    void clear();
+    /**
+ * Removes all registered mock metadata from the registry.
+ *
+ * After invocation, the registry will contain no entries.
+ */
+void clear();
 }

--- a/backend/src/main/java/kr/co/ouroboros/core/rest/mock/registry/RestMockRegistry.java
+++ b/backend/src/main/java/kr/co/ouroboros/core/rest/mock/registry/RestMockRegistry.java
@@ -97,7 +97,9 @@ public class RestMockRegistry implements MockRegistryBase<EndpointMeta> {
     }
 
     /**
-     * Clears all registered mock endpoints and pattern cache.
+     * Reset the registry state by removing all registered endpoints and cached patterns.
+     *
+     * After invocation the registry contains no endpoints and the pattern cache is empty.
      */
     @Override
     public void clear() {
@@ -105,6 +107,12 @@ public class RestMockRegistry implements MockRegistryBase<EndpointMeta> {
         patternCache.clear();
     }
 
+    /**
+     * Normalize a request path by removing a trailing '/' except when the path is a single "/".
+     *
+     * @param path the original request path
+     * @return the normalized path with a trailing slash removed if the path length is greater than 1
+     */
     private String normalizePath(String path) {
         // 끝의 슬래시 제거
         if (path.endsWith("/") && path.length() > 1) {

--- a/backend/src/main/java/kr/co/ouroboros/core/rest/spec/service/RestApiSpecServiceimpl.java
+++ b/backend/src/main/java/kr/co/ouroboros/core/rest/spec/service/RestApiSpecServiceimpl.java
@@ -47,6 +47,18 @@ public class RestApiSpecServiceimpl implements RestApiSpecService {
             "get", "post", "put", "delete", "patch", "options", "head", "trace"
     );
 
+    /**
+     * Create and persist a new REST API operation in the OpenAPI document.
+     *
+     * The operation is added under the given path and HTTP method, missing security schemes
+     * and schemas are auto-created as needed, the spec cache is updated, and registered mocks
+     * are reloaded from the persisted YAML.
+     *
+     * @param request the request describing the API operation to create (path, method, metadata, security, etc.)
+     * @return a RestApiSpecResponse describing the newly created operation (id, path, method, summary, etc.)
+     * @throws IllegalArgumentException if an operation for the same path and method already exists
+     * @throws Exception for failures reading/writing or processing the OpenAPI document
+     */
     @Override
     public RestApiSpecResponse createRestApiSpec(CreateRestApiRequest request) throws Exception {
         lock.writeLock().lock();
@@ -179,6 +191,16 @@ public class RestApiSpecServiceimpl implements RestApiSpecService {
         }
     }
 
+    /**
+     * Updates an existing REST API specification identified by its Ouroboros ID, optionally changing its path, method, and other operation fields.
+     *
+     * Updates are persisted into the OpenAPI document, missing security schemes and schemas are auto-created as needed, the spec cache is refreshed, and the mock registry is reloaded.
+     *
+     * @param id      the x-ouroboros-id value of the operation to update
+     * @param request the update request containing fields to change (path, method, summary, description, parameters, requestBody, responses, security, etc.)
+     * @return the updated RestApiSpecResponse for the operation at its final path and method
+     * @throws IllegalArgumentException if the specification file does not exist, if no operation with the given id is found, or if moving the operation would conflict with an existing operation at the target path/method
+     */
     @Override
     public RestApiSpecResponse updateRestApiSpec(String id, UpdateRestApiRequest request) throws Exception {
         lock.writeLock().lock();
@@ -278,6 +300,14 @@ public class RestApiSpecServiceimpl implements RestApiSpecService {
         }
     }
 
+    /**
+     * Deletes the REST API specification identified by the given ID from the stored OpenAPI document.
+     *
+     * Updates the persisted document, refreshes the in-memory spec cache, and reloads the mock registry after removal.
+     *
+     * @param id the `x-ouroboros-id` value of the REST API operation to remove
+     * @throws IllegalArgumentException if the specification file does not exist or no operation with the given ID is found
+     */
     @Override
     public void deleteRestApiSpec(String id) throws Exception {
         lock.writeLock().lock();


### PR DESCRIPTION
## 📌 Summary
Provide a brief summary of what this PR does and why it’s needed.

> 명세 작성, 수정, 삭제 시 registry 등록을 즉석으로 재개하도록 수정하였습니다. 

---

## ✅ Type of Change
Check all that apply.

- [ ] ✨ Feature (new functionality)
- [X] 🐞 Bug fix (non-breaking fix)
- [ ] ♻️ Refactor (code restructuring with no behavior change)
- [ ] 🧪 Test (adding or updating tests)
- [ ] 📝 Documentation (updates to README or other docs)
- [ ] 🎨 Style (formatting, naming, or lint fixes)
- [ ] 🚀 Performance (improves efficiency or speed)
- [ ] 🔧 Chore (build, CI, dependencies, etc.)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API 스펙(생성/수정/삭제) 및 스키마 변경 시 모의 엔드포인트가 자동으로 재로드되어 즉시 반영됩니다.
  * 모의 레지스트리를 완전히 초기화(등록된 엔드포인트 및 캐시 제거)하는 기능이 공개되어 수동 재설정이 가능합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->