### PR TITLE
[FIX]루트 스키마 선택, 스니펫 및 테스트 요청 대응

### DIFF
--- a/backend/src/main/java/kr/co/ouroboros/core/rest/mock/service/MockValidationService.java
+++ b/backend/src/main/java/kr/co/ouroboros/core/rest/mock/service/MockValidationService.java
@@ -357,9 +357,9 @@ public class MockValidationService {
     private ValidationResult validateArrayItems(List<Object> array,
                                                 Map<String, Object> itemSchema,
                                                 String fieldPath) {
-        // $ref 처리 - items에서도 스키마 참조 가능
-        if (itemSchema.containsKey("$ref")) {
-            String ref = (String) itemSchema.get("$ref");
+        // $ref 또는 ref 처리 - items에서도 스키마 참조 가능
+        if (itemSchema.containsKey("$ref") || itemSchema.containsKey("ref")) {
+            String ref = (String) (itemSchema.get("$ref") != null ? itemSchema.get("$ref") : itemSchema.get("ref"));
             itemSchema = resolveSchemaRef(ref);
             if (itemSchema == null) {
                 log.warn("Failed to resolve array item schema ref: {}", ref);

--- a/backend/src/main/java/kr/co/ouroboros/core/rest/spec/service/RestApiSpecServiceimpl.java
+++ b/backend/src/main/java/kr/co/ouroboros/core/rest/spec/service/RestApiSpecServiceimpl.java
@@ -21,6 +21,7 @@ import org.yaml.snakeyaml.Yaml;
 import java.util.*;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.stream.Collectors;
 
 /**
  * Implementation of {@link RestApiSpecService}.
@@ -371,7 +372,11 @@ public class RestApiSpecServiceimpl implements RestApiSpecService {
         }
 
         if (request.getTags() != null && !request.getTags().isEmpty()) {
-            operation.put("tags", request.getTags());
+            // tags를 대문자로 변환
+            List<String> upperCaseTags = request.getTags().stream()
+                    .map(String::toUpperCase)
+                    .collect(Collectors.toList());
+            operation.put("tags", upperCaseTags);
         }
 
         if (request.getParameters() != null && !request.getParameters().isEmpty()) {
@@ -429,7 +434,11 @@ public class RestApiSpecServiceimpl implements RestApiSpecService {
                 operation.remove("tags");
                 log.info("✓ Tags removed from operation");
             } else {
-                operation.put("tags", request.getTags());
+                // tags를 대문자로 변환
+                List<String> upperCaseTags = request.getTags().stream()
+                        .map(String::toUpperCase)
+                        .collect(Collectors.toList());
+                operation.put("tags", upperCaseTags);
             }
         }
 
@@ -1105,6 +1114,18 @@ public class RestApiSpecServiceimpl implements RestApiSpecService {
 
                 // Update $ref references in the operation
                 updateSchemaReferences(operation, schemaRenameMap);
+
+                // tags를 대문자로 변환
+                if (operation.containsKey("tags") && operation.get("tags") instanceof List) {
+                    @SuppressWarnings("unchecked")
+                    List<Object> tagsObj = (List<Object>) operation.get("tags");
+                    if (tagsObj != null && !tagsObj.isEmpty()) {
+                        List<String> upperCaseTags = tagsObj.stream()
+                                .map(obj -> obj.toString().toUpperCase())
+                                .collect(Collectors.toList());
+                        operation.put("tags", upperCaseTags);
+                    }
+                }
 
                 // Enrich operation with Ouroboros fields
                 enrichOperationWithOuroborosFields(operation);

--- a/front/src/features/spec/components/ApiRequestCard.tsx
+++ b/front/src/features/spec/components/ApiRequestCard.tsx
@@ -2,8 +2,18 @@ import { useState, useEffect } from "react";
 import { SchemaModal } from "./SchemaModal";
 import { SchemaFieldEditor } from "./SchemaFieldEditor";
 import { getAllSchemas, type SchemaResponse } from "../services/api";
-import type { RequestBody, SchemaField } from "../types/schema.types";
-import { createDefaultField } from "../types/schema.types";
+import type { RequestBody, SchemaField, SchemaType, PrimitiveTypeName } from "../types/schema.types";
+import { 
+  createDefaultField, 
+  createPrimitiveField,
+  createObjectField,
+  createArrayField,
+  createRefField,
+  isPrimitiveSchema,
+  isObjectSchema,
+  isArraySchema,
+  isRefSchema,
+} from "../types/schema.types";
 
 // UTF-8 문자열을 Base64로 안전하게 인코딩하는 함수
 const safeBase64 = (value: string): string | null => {
@@ -124,12 +134,23 @@ export function ApiRequestCard({
     name: string;
     fields: SchemaField[];
   }) => {
-    // SchemaModal에서 이미 재귀적으로 변환된 필드를 그대로 사용
+    // rootSchemaType이 ref 타입이면 rootSchemaType 업데이트
+    if (requestBody.rootSchemaType && isRefSchema(requestBody.rootSchemaType)) {
+      setRequestBody({
+        ...requestBody,
+        rootSchemaType: {
+          kind: "ref",
+          schemaName: schema.name,
+        },
+      });
+    } else {
+      // 기존 방식: SchemaModal에서 이미 재귀적으로 변환된 필드를 그대로 사용
     setRequestBody({
       ...requestBody,
       schemaRef: schema.name,
       fields: schema.fields,
     });
+    }
   };
 
   return (
@@ -262,7 +283,9 @@ export function ApiRequestCard({
                   onClick={() => {
                     const newBody: RequestBody = {
                       type: type,
-                      fields: type === "none" ? [] : [createDefaultField()],
+                      fields: type === "none" ? [] : (type === "json" || type === "xml" ? [] : [createDefaultField()]),
+                      // json/xml일 때는 rootSchemaType을 object로 기본 설정
+                      rootSchemaType: (type === "json" || type === "xml") ? createObjectField("").schemaType : undefined,
                     };
                     setRequestBody(newBody);
                   }}
@@ -279,8 +302,55 @@ export function ApiRequestCard({
             </div>
 
             {/* Table Format for all types except none */}
-            {requestBody.type !== "none" && requestBody.fields && (
+            {requestBody.type !== "none" && (
               <div>
+                {/* JSON/XML 타입일 때 Root Type 선택 */}
+                {(requestBody.type === "json" || requestBody.type === "xml") && (
+                  <div className="mb-4">
+                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                      Root Type
+                    </label>
+                    <select
+                      value={requestBody.rootSchemaType?.kind || "object"}
+                      onChange={(e) => {
+                        const kind = e.target.value as SchemaType["kind"];
+                        let newRootSchemaType: SchemaType;
+                        
+                        switch (kind) {
+                          case "object":
+                            newRootSchemaType = createObjectField("").schemaType;
+                            break;
+                          case "array":
+                            newRootSchemaType = createArrayField("").schemaType;
+                            break;
+                          case "primitive":
+                            newRootSchemaType = createPrimitiveField("", "string").schemaType;
+                            break;
+                          case "ref":
+                            newRootSchemaType = createRefField("", "").schemaType;
+                            break;
+                          default:
+                            newRootSchemaType = createObjectField("").schemaType;
+                        }
+                        
+                        setRequestBody({
+                          ...requestBody,
+                          rootSchemaType: newRootSchemaType,
+                          fields: kind === "object" ? [] : undefined,
+                          schemaRef: undefined,
+                        });
+                      }}
+                      disabled={isReadOnly}
+                      className="w-full px-3 py-2 border border-gray-300 dark:border-[#2D333B] rounded-md bg-white dark:bg-[#0D1117] text-gray-900 dark:text-[#E6EDF3] focus:outline-none focus:ring-1 focus:ring-[#2563EB] focus:border-[#2563EB] text-sm"
+                    >
+                      <option value="object">Object</option>
+                      <option value="array">Array</option>
+                      <option value="primitive">Primitive (string, number, etc.)</option>
+                      <option value="ref">Schema Reference</option>
+                    </select>
+                  </div>
+                )}
+
                 <div className="mb-3 flex gap-2 items-center">
                   {/* Schema 참조 표시 */}
                   {requestBody.schemaRef && (
@@ -307,6 +377,9 @@ export function ApiRequestCard({
                     </div>
                   )}
                   
+                  {/* JSON/XML이 아닐 때만 Add Field 버튼 표시 */}
+                  {requestBody.type !== "json" && requestBody.type !== "xml" && (
+                    <>
                   <button
                     onClick={() => {
                       setRequestBody({
@@ -333,11 +406,210 @@ export function ApiRequestCard({
                   >
                     {requestBody.schemaRef ? "Change Schema" : "+ Add Schema"}
                   </button>
+                    </>
+                  )}
                 </div>
                 
-                {/* 새로운 재귀적 SchemaField Editor */}
+                {/* JSON/XML 타입일 때 Root Type에 따른 편집 UI */}
+                {(requestBody.type === "json" || requestBody.type === "xml") && requestBody.rootSchemaType && (
+                  <div>
+                    {/* Object 타입 */}
+                    {isObjectSchema(requestBody.rootSchemaType) && (() => {
+                      const objectSchema = requestBody.rootSchemaType;
+                      return (
+                        <div>
+                          <div className="mb-3 flex gap-2 items-center">
+                            <button
+                              onClick={() => {
+                                setRequestBody({
+                                  ...requestBody,
+                                  rootSchemaType: {
+                                    ...objectSchema,
+                                    properties: [
+                                      ...objectSchema.properties,
+                                      createDefaultField(),
+                                    ],
+                                  },
+                                });
+                              }}
+                              disabled={isReadOnly}
+                              className={`px-3 py-1 text-sm text-[#2563EB] hover:text-[#1E40AF] font-medium ${
+                                isReadOnly ? "opacity-50 cursor-not-allowed" : ""
+                              }`}
+                            >
+                              + Add Field
+                            </button>
+                            <button
+                              onClick={() => setIsSchemaModalOpen(true)}
+                              disabled={isReadOnly}
+                              className={`px-3 py-1 text-sm text-emerald-600 hover:text-emerald-700 font-medium ${
+                                isReadOnly ? "opacity-50 cursor-not-allowed" : ""
+                              }`}
+                            >
+                              + Add Schema
+                            </button>
+                          </div>
+                          <div className="space-y-2">
+                            {objectSchema.properties.map((field, index) => (
+                              <SchemaFieldEditor
+                                key={index}
+                                field={field}
+                                onChange={(newField) => {
+                                  const updated = [...objectSchema.properties];
+                                  updated[index] = newField;
+                                  setRequestBody({
+                                    ...requestBody,
+                                    rootSchemaType: {
+                                      ...objectSchema,
+                                      properties: updated,
+                                    },
+                                  });
+                                }}
+                                onRemove={() => {
+                                  const updated = objectSchema.properties.filter((_, i) => i !== index);
+                                  setRequestBody({
+                                    ...requestBody,
+                                    rootSchemaType: {
+                                      ...objectSchema,
+                                      properties: updated,
+                                    },
+                                  });
+                                }}
+                                isReadOnly={isReadOnly}
+                                allowFileType={false}
+                              />
+                            ))}
+                          </div>
+                          {(!objectSchema.properties || objectSchema.properties.length === 0) && (
+                            <div className="text-center py-8 text-gray-500 dark:text-gray-400 text-sm">
+                              <p>No fields yet. Click "+ Add Field" to add one.</p>
+                            </div>
+                          )}
+                        </div>
+                      );
+                    })()}
+
+                    {/* Array 타입 */}
+                    {isArraySchema(requestBody.rootSchemaType) && (
+                      <div>
+                        <p className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                          Array Items:
+                        </p>
+                        <div className="ml-4">
+                          <SchemaFieldEditor
+                            field={{
+                              key: "items",
+                              schemaType: requestBody.rootSchemaType.items,
+                              description: requestBody.rootSchemaType.itemsDescription,
+                              required: requestBody.rootSchemaType.itemsRequired,
+                            }}
+                            onChange={(newField) => {
+                              setRequestBody({
+                                ...requestBody,
+                                rootSchemaType: {
+                                  ...requestBody.rootSchemaType!,
+                                  items: newField.schemaType,
+                                  itemsDescription: newField.description,
+                                  itemsRequired: newField.required,
+                                } as typeof requestBody.rootSchemaType,
+                              });
+                            }}
+                            depth={0}
+                            isReadOnly={isReadOnly}
+                            allowFileType={false}
+                          />
+                          <div className="flex gap-2 mt-2">
+                            <input
+                              type="number"
+                              value={requestBody.rootSchemaType.minItems || ""}
+                              onChange={(e) => {
+                                setRequestBody({
+                                  ...requestBody,
+                                  rootSchemaType: {
+                                    ...requestBody.rootSchemaType!,
+                                    minItems: e.target.value ? parseInt(e.target.value) : undefined,
+                                  } as typeof requestBody.rootSchemaType,
+                                });
+                              }}
+                              placeholder="Min items"
+                              disabled={isReadOnly}
+                              className="px-2 py-1 text-xs rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900"
+                            />
+                            <input
+                              type="number"
+                              value={requestBody.rootSchemaType.maxItems || ""}
+                              onChange={(e) => {
+                                setRequestBody({
+                                  ...requestBody,
+                                  rootSchemaType: {
+                                    ...requestBody.rootSchemaType!,
+                                    maxItems: e.target.value ? parseInt(e.target.value) : undefined,
+                                  } as typeof requestBody.rootSchemaType,
+                                });
+                              }}
+                              placeholder="Max items"
+                              disabled={isReadOnly}
+                              className="px-2 py-1 text-xs rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900"
+                            />
+                          </div>
+                        </div>
+                      </div>
+                    )}
+
+                    {/* Primitive 타입 */}
+                    {isPrimitiveSchema(requestBody.rootSchemaType) && (
+                      <div>
+                        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                          Primitive Type
+                        </label>
+                        <select
+                          value={requestBody.rootSchemaType.type}
+                          onChange={(e) => {
+                            setRequestBody({
+                              ...requestBody,
+                              rootSchemaType: {
+                                ...requestBody.rootSchemaType!,
+                                type: e.target.value as PrimitiveTypeName,
+                                format: e.target.value === "file" ? "binary" : undefined,
+                              } as typeof requestBody.rootSchemaType,
+                            });
+                          }}
+                          disabled={isReadOnly}
+                          className="w-full px-3 py-2 border border-gray-300 dark:border-[#2D333B] rounded-md bg-white dark:bg-[#0D1117] text-gray-900 dark:text-[#E6EDF3] focus:outline-none focus:ring-1 focus:ring-[#2563EB] focus:border-[#2563EB] text-sm"
+                        >
+                          <option value="string">string</option>
+                          <option value="integer">integer</option>
+                          <option value="number">number</option>
+                          <option value="boolean">boolean</option>
+                        </select>
+                      </div>
+                    )}
+
+                    {/* Ref 타입 */}
+                    {isRefSchema(requestBody.rootSchemaType) && (
+                      <div>
+                        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                          Schema Reference
+                        </label>
+                        <button
+                          onClick={() => setIsSchemaModalOpen(true)}
+                          disabled={isReadOnly}
+                          className={`w-full px-3 py-2 border border-gray-300 dark:border-[#2D333B] rounded-md bg-white dark:bg-[#0D1117] text-gray-900 dark:text-[#E6EDF3] text-left hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors disabled:opacity-50 text-sm ${
+                            isReadOnly ? "opacity-50 cursor-not-allowed" : ""
+                          }`}
+                        >
+                          {requestBody.rootSchemaType.schemaName || "Select Schema..."}
+                        </button>
+                      </div>
+                    )}
+                  </div>
+                )}
+
+                {/* JSON/XML이 아닐 때 기존 필드 편집 UI */}
+                {requestBody.type !== "json" && requestBody.type !== "xml" && requestBody.fields && (
+                  <>
                 <div className="space-y-2">
-                  {requestBody.fields && requestBody.fields.map((field, index) => (
+                      {requestBody.fields.map((field, index) => (
                     <SchemaFieldEditor
                       key={index}
                       field={field}
@@ -366,6 +638,8 @@ export function ApiRequestCard({
                   <div className="text-center py-8 text-gray-500 dark:text-gray-400 text-sm">
                     <p>No fields yet. Click "+ Add Field" to add one.</p>
                   </div>
+                    )}
+                  </>
                 )}
               </div>
             )}

--- a/front/src/features/spec/components/CodeSnippetPanel.tsx
+++ b/front/src/features/spec/components/CodeSnippetPanel.tsx
@@ -1,37 +1,12 @@
-import { useState } from "react";
-// @ts-expect-error - openapi-snippet has no type definitions
-import OpenAPISnippet from "openapi-snippet";
-import type { RequestBody } from "../types/schema.types";
-import { convertRequestBodyToOpenAPI } from "../utils/schemaConverter";
-
-interface KeyValuePair {
-  key: string;
-  value: string;
-  required?: boolean;
-  description?: string;
-  type?: string;
-}
+import { useState, useEffect } from "react";
+import type { RestApiSpecResponse } from "../services/api";
+import { getSchema } from "../services/api";
 
 interface CodeSnippetPanelProps {
   isOpen: boolean;
   onClose: () => void;
-  method: string;
-  url: string;
-  headers: KeyValuePair[];
-  requestBody?: RequestBody;
+  spec: RestApiSpecResponse | null;
 }
-
-// openapi-snippet의 target 매핑
-const languageTargets: Record<string, string> = {
-  javascript: "javascript_fetch",
-  typescript: "javascript_fetch", // TypeScript는 JavaScript와 동일한 target 사용
-  python: "python_requests",
-  curl: "shell_curl",
-  shell: "shell_curl",
-  java: "java_okhttp",
-  swift: "swift_urlsession",
-  go: "go_native",
-};
 
 const languages = [
   { id: "javascript", name: "JavaScript" },
@@ -44,171 +19,168 @@ const languages = [
   { id: "go", name: "Go" },
 ];
 
-// OpenAPI 스펙을 구성하는 함수
-function buildOpenAPISpec(
-  method: string,
-  url: string,
-  headers: KeyValuePair[],
-  requestBody?: RequestBody
-): any {
-  // 환경변수에서 base URL 가져오기 (없으면 기본값 사용)
-  const baseUrl = import.meta.env.VITE_API_BASE_URL || "http://localhost:8080";
+// 스키마에서 기본값 생성 (재귀)
+function generateDefaultValue(schema: any, schemas: Record<string, any> = {}): any {
+  if (!schema) return undefined;
 
-  const openApiSpec: any = {
-    openapi: "3.1.0",
-    info: {
-      title: "API Documentation",
-      version: "1.0.0",
-    },
-    servers: [
-      {
-        url: baseUrl,
-        description: "API Server",
-      },
-    ],
-    paths: {},
-  };
-
-  // Parameters를 OpenAPI 형식으로 변환 (headers)
-  const parameters: any[] = [];
-  headers.forEach((header) => {
-    if (header.key && header.value) {
-      parameters.push({
-        name: header.key,
-        in: "header",
-        required: header.required || false,
-        schema: {
-          type: "string",
-        },
-        description: header.description || "",
-      });
+  // $ref 또는 ref 처리
+  if (schema.$ref || schema.ref) {
+    const refName = (schema.$ref || schema.ref)
+      .replace("#/components/schemas/", "")
+      .replace("components/schemas/", "");
+    const refSchema = schemas[refName];
+    if (refSchema) {
+      return generateDefaultValue(refSchema, schemas);
     }
-  });
+    // 스키마를 찾을 수 없으면 빈 객체
+    return {};
+  }
 
-  // RequestBody를 OpenAPI 형식으로 변환
-  let openApiRequestBody = requestBody
-    ? convertRequestBodyToOpenAPI(requestBody)
-    : null;
+  // array 타입
+  if (schema.type === "array") {
+    if (schema.items) {
+      const itemValue = generateDefaultValue(schema.items, schemas);
+      return itemValue !== undefined ? [itemValue] : [];
+    }
+    return [];
+  }
 
-  // schemaRef가 있는 경우 $ref를 제거 (components 섹션이 없으므로)
-  // openapi-snippet은 $ref를 처리하려면 components 섹션이 필요함
-  if (openApiRequestBody?.content) {
-    const contentTypes = Object.keys(openApiRequestBody.content);
-    for (const contentType of contentTypes) {
-      const mediaType = openApiRequestBody.content[contentType];
-      // $ref나 ref가 있으면 제거 (이미 generateSnippet에서 schemaRef 체크하지만 안전장치)
-      if (mediaType?.schema?.$ref || mediaType?.schema?.ref) {
-        // schemaRef가 있는 경우 requestBody를 null로 설정하여 fallback 사용
-        openApiRequestBody = null;
-        break; // null로 설정했으므로 더 이상 처리할 필요 없음
+  // object 타입
+  if (schema.type === "object" && schema.properties) {
+    const obj: any = {};
+    Object.entries(schema.properties).forEach(([key, propSchema]: [string, any]) => {
+      const value = generateDefaultValue(propSchema, schemas);
+      if (value !== undefined) {
+        obj[key] = value;
+      }
+    });
+    return Object.keys(obj).length > 0 ? obj : undefined;
+  }
+
+  // primitive 타입
+  if (schema.type === "string") return "string";
+  if (schema.type === "integer" || schema.type === "number") return 0;
+  if (schema.type === "boolean") return false;
+
+  return undefined;
+}
+
+// RequestBody에서 body 값 생성
+async function generateBodyValue(requestBody: any): Promise<any> {
+  if (!requestBody || !requestBody.content) return undefined;
+
+  const contentType = Object.keys(requestBody.content)[0];
+  if (!contentType) return undefined;
+
+  const mediaType = requestBody.content[contentType];
+  if (!mediaType || !mediaType.schema) return undefined;
+
+  const schema = mediaType.schema;
+  const schemas: Record<string, any> = {};
+
+  // $ref 또는 ref가 있으면 스키마 조회
+  if (schema.$ref || schema.ref) {
+    const refName = (schema.$ref || schema.ref)
+      .replace("#/components/schemas/", "")
+      .replace("components/schemas/", "");
+    try {
+      const response = await getSchema(refName);
+      schemas[refName] = response.data;
+    } catch {
+      // 스키마 조회 실패 시 빈 객체 반환
+      return {};
+    }
+  }
+
+  // array의 items에 ref가 있는 경우
+  if (schema.type === "array" && schema.items) {
+    if (schema.items.$ref || schema.items.ref) {
+      const refName = (schema.items.$ref || schema.items.ref)
+        .replace("#/components/schemas/", "")
+        .replace("components/schemas/", "");
+      try {
+        const response = await getSchema(refName);
+        const refSchema = response.data;
+        schemas[refName] = refSchema;
+        // ref 스키마를 items로 사용하여 generateDefaultValue 호출
+        const itemValue = generateDefaultValue(refSchema, schemas);
+        return itemValue !== undefined ? [itemValue] : [{}];
+      } catch {
+        return [{}];
       }
     }
   }
 
-  // Operation 구성
-  const operation: any = {
-    summary: `${method} ${url}`,
-    operationId: `${method.toLowerCase()}_${url
-      .replace(/\//g, "_")
-      .replace(/[{}]/g, "")}`,
-  };
-
-  if (parameters.length > 0) {
-    operation.parameters = parameters;
-  }
-
-  if (openApiRequestBody) {
-    operation.requestBody = openApiRequestBody;
-  }
-
-  // Path 구성
-  openApiSpec.paths[url] = {
-    [method.toLowerCase()]: operation,
-  };
-
-  return openApiSpec;
+  return generateDefaultValue(schema, schemas);
 }
 
 export function CodeSnippetPanel({
   isOpen,
   onClose,
-  method,
-  url,
-  headers,
-  requestBody,
+  spec,
 }: CodeSnippetPanelProps) {
   const [selectedLanguage, setSelectedLanguage] = useState("javascript");
   const [copied, setCopied] = useState(false);
+  const [snippet, setSnippet] = useState("");
+  const [loading, setLoading] = useState(false);
 
-  const generateSnippet = (lang: string): string => {
-    const langConfig = languages.find((l) => l.id === lang);
-    if (!langConfig) return "";
-
-    // schemaRef가 있는 경우 openapi-snippet을 사용하지 않고 fallback 사용
-    // (components 섹션이 없어서 $ref를 처리할 수 없음)
-    if (requestBody?.schemaRef) {
-      return generateFallbackSnippet(lang, method, url, headers, requestBody);
+  useEffect(() => {
+    if (!isOpen || !spec) {
+      setSnippet("");
+      return;
     }
 
-    const target = languageTargets[lang];
-    if (!target) {
-      // 지원하지 않는 언어는 fallback 사용
-      return generateFallbackSnippet(lang, method, url, headers, requestBody);
-    }
+    const generateSnippet = async () => {
+      setLoading(true);
+      try {
+        const method = spec.method;
+        const url = spec.path;
+        const baseUrl = import.meta.env.VITE_API_BASE_URL || "http://localhost:8080";
+        const fullUrl = `${baseUrl}${url}`;
 
-    try {
-      // OpenAPI 스펙 구성
-      const openApiSpec = buildOpenAPISpec(method, url, headers, requestBody);
-
-      // openapi-snippet을 사용하여 코드 생성
-      const result = OpenAPISnippet.getEndpointSnippets(
-        openApiSpec,
-        url,
-        method.toLowerCase(),
-        [target]
-      );
-
-      // 반환값 처리 (제공하신 예제 + 보완)
-      if (result) {
-        // result.snippets가 있는 경우
-        if (
-          result.snippets &&
-          Array.isArray(result.snippets) &&
-          result.snippets.length > 0
-        ) {
-          const snippet = result.snippets[0];
-          return snippet.content || snippet.snippet || "";
+        // Headers 추출
+        const headers: Record<string, string> = {};
+        if (spec.parameters && Array.isArray(spec.parameters)) {
+          spec.parameters.forEach((param: any) => {
+            if (param.in === "header" && param.name) {
+              headers[param.name] = param.schema?.default || "";
+            }
+          });
         }
-        // result 자체가 배열인 경우
-        if (Array.isArray(result) && result.length > 0) {
-          const snippet = result[0];
-          return (
-            snippet.content ||
-            snippet.snippet ||
-            (typeof snippet === "string" ? snippet : "")
-          );
+
+        // RequestBody 처리
+        let bodyValue: any = undefined;
+        if (spec.requestBody && method !== "GET") {
+          bodyValue = await generateBodyValue(spec.requestBody);
         }
-        // result에 직접 content나 snippet이 있는 경우
-        if (result.content) return result.content;
-        if (result.snippet) return result.snippet;
-        if (typeof result === "string") return result;
+
+        // 스니펫 생성
+        const snippet = generateCodeSnippet(
+          selectedLanguage,
+          method,
+          fullUrl,
+          headers,
+          bodyValue
+        );
+        setSnippet(snippet);
+      } catch (error) {
+        console.error("스니펫 생성 실패:", error);
+        setSnippet("// 스니펫 생성 중 오류가 발생했습니다.");
+      } finally {
+        setLoading(false);
       }
-    } catch {
-      // 에러 발생 시 fallback 사용
-    }
+    };
 
-    // openapi-snippet이 실패하거나 지원하지 않는 경우 fallback
-    return generateFallbackSnippet(lang, method, url, headers, requestBody);
-  };
+    generateSnippet();
+  }, [isOpen, spec, selectedLanguage]);
 
   const copyToClipboard = () => {
-    const code = generateSnippet(selectedLanguage);
-    navigator.clipboard.writeText(code);
+    navigator.clipboard.writeText(snippet);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   };
 
-  if (!isOpen) return null;
+  if (!isOpen || !spec) return null;
 
   return (
     <>
@@ -281,19 +253,26 @@ export function CodeSnippetPanel({
           <div className="bg-gray-50 dark:bg-[#0D1117] rounded-md border border-gray-200 dark:border-[#2D333B] overflow-hidden">
             <div className="flex items-center justify-between bg-white dark:bg-[#161B22] px-4 py-2 border-b border-gray-200 dark:border-[#2D333B]">
               <span className="text-sm text-gray-600 dark:text-[#8B949E] font-mono">
-                {method} {url}
+                {spec.method} {spec.path}
               </span>
               <button
                 onClick={copyToClipboard}
-                className="px-3 py-1 text-sm bg-[#2563EB] hover:bg-[#1E40AF] text-white rounded-md transition-colors"
+                disabled={loading || !snippet}
+                className="px-3 py-1 text-sm bg-[#2563EB] hover:bg-[#1E40AF] text-white rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 {copied ? "복사됨" : "복사"}
               </button>
             </div>
             <div className="bg-[#0D1117] dark:bg-[#010409] p-4 rounded-md">
+              {loading ? (
+                <div className="text-sm text-[#E6EDF3] text-center py-8">
+                  스니펫 생성 중...
+                </div>
+              ) : (
               <pre className="text-sm text-[#E6EDF3] whitespace-pre-wrap overflow-x-auto font-mono">
-                <code>{generateSnippet(selectedLanguage)}</code>
+                  <code>{snippet || "// 스니펫을 생성할 수 없습니다."}</code>
               </pre>
+              )}
             </div>
           </div>
         </div>
@@ -302,251 +281,174 @@ export function CodeSnippetPanel({
   );
 }
 
-// Fallback 함수: openapi-snippet이 실패하거나 지원하지 않는 경우
-function generateFallbackSnippet(
+// 코드 스니펫 생성 함수
+function generateCodeSnippet(
   lang: string,
   method: string,
   url: string,
-  headers: KeyValuePair[],
-  requestBody?: RequestBody
+  headers: Record<string, string>,
+  bodyValue?: any
 ): string {
-  const headerString = headers
-    .filter((h) => h.key && h.value)
-    .map((h) => {
-      if (lang === "javascript" || lang === "typescript") {
-        return `  "${h.key}": "${h.value}"`;
-      } else if (lang === "python") {
-        return `    "${h.key}": "${h.value}"`;
-      } else if (lang === "curl" || lang === "shell") {
-        return `  -H "${h.key}: ${h.value}"`;
-      } else if (lang === "java") {
-        return `      .header("${h.key}", "${h.value}")`;
-      } else if (lang === "swift") {
-        return `    "${h.key}": "${h.value}"`;
-      } else if (lang === "go") {
-        return `    req.Header.Set("${h.key}", "${h.value}")`;
-      }
-      return "";
-    })
-    .filter(Boolean)
-    .join(lang === "curl" || lang === "shell" ? " \\\n" : "\n");
-
-  // RequestBody 처리 개선
-  let bodyString = "";
-  let bodyVar = "";
-  if (requestBody && method !== "GET" && requestBody.type !== "none") {
-    // requestBody에서 실제 값을 추출
-    const bodyValue = extractRequestBodyValue(requestBody);
-
-    if (bodyValue !== undefined) {
-      if (requestBody.type === "json") {
-        const bodyJson = JSON.stringify(bodyValue, null, 2);
-        if (lang === "javascript") {
-          bodyVar = `\n\nconst body = ${bodyJson};`;
-          bodyString = `\n  body: JSON.stringify(body)`;
-        } else if (lang === "typescript") {
-          bodyVar = `\n\nconst body: Record<string, any> = ${bodyJson};`;
-          bodyString = `\n  body: JSON.stringify(body)`;
-        } else if (lang === "python") {
-          bodyVar = `\n\nbody = ${bodyJson}`;
-          bodyString = `\n    json=body`;
-        } else if (lang === "curl" || lang === "shell") {
-          bodyString = ` -d '${JSON.stringify(bodyValue)}'`;
-        } else if (lang === "swift") {
-          const swiftDict = Object.entries(bodyValue)
-            .map(([k, v]) => `    "${k}": ${JSON.stringify(v)}`)
-            .join(",\n");
-          bodyVar = `\n\nlet body: [String: Any] = [\n${swiftDict}\n]`;
-          bodyString = `\nrequest.httpBody = try? JSONSerialization.data(withJSONObject: body)`;
-        } else if (lang === "go") {
-          const goMap = Object.entries(bodyValue)
-            .map(([k, v]) => `        "${k}": ${JSON.stringify(v)}`)
-            .join(",\n");
-          bodyVar = `\n\nbody := map[string]interface{}{\n${goMap}\n}`;
-          bodyString = `jsonBody, _ := json.Marshal(body)\nreq, _ := http.NewRequest("${method}", "${url}", bytes.NewBuffer(jsonBody))`;
-        }
-      } else if (requestBody.type === "form-data") {
-        // Form-data 처리
-        if (lang === "python") {
-          bodyVar = `\n\nfiles = ${JSON.stringify(bodyValue)}`;
-          bodyString = `\n    files=files`;
-        } else if (lang === "curl" || lang === "shell") {
-          const formData = Object.entries(bodyValue)
-            .map(([k, v]) => `-F "${k}=${v}"`)
-            .join(" \\\n  ");
-          bodyString = ` \\\n  ${formData}`;
-        }
-      } else if (requestBody.type === "x-www-form-urlencoded") {
-        // URL-encoded 처리
-        if (lang === "python") {
-          bodyVar = `\n\ndata = ${JSON.stringify(bodyValue)}`;
-          bodyString = `\n    data=data`;
-        } else if (lang === "curl" || lang === "shell") {
-          const formData = Object.entries(bodyValue)
-            .map(
-              ([k, v]) =>
-                `${encodeURIComponent(k)}=${encodeURIComponent(String(v))}`
-            )
-            .join("&");
-          bodyString = ` -d '${formData}'`;
-        }
-      } else if (requestBody.type === "xml") {
-        // XML 처리
-        if (lang === "curl" || lang === "shell") {
-          bodyString = ` -d '${bodyValue}'`;
-        }
-      }
-    }
-  }
+  const headerEntries = Object.entries(headers).filter(([_, v]) => v);
+  const hasBody = bodyValue !== undefined && method !== "GET";
 
   switch (lang) {
-    case "javascript":
-      return `const response = await fetch("${url}", {
-  method: "${method}",
-  headers: {
-${headerString}
-  }${bodyString}
-});${bodyVar}`;
+    case "javascript": {
+      const headerStr = headerEntries
+        .map(([k, v]) => `    "${k}": "${v}"`)
+        .join(",\n");
+      const headersPart = headerStr
+        ? `  headers: {\n${headerStr}\n  },`
+        : "";
+      const bodyPart = hasBody
+        ? `\n  body: JSON.stringify(${JSON.stringify(bodyValue, null, 2)})`
+        : "";
 
-    case "typescript":
-      return `const response: Response = await fetch("${url}", {
-  method: "${method}",
-  headers: {
-${headerString}
-  }${bodyString}
-});${bodyVar}`;
+      return `const options = {
+  method: '${method}'${headersPart ? `,\n${headersPart}` : ""}${bodyPart}
+};
 
-    case "python":
+fetch('${url}', options)
+  .then(response => response.json())
+  .then(data => console.log(data))
+  .catch(err => console.error(err));`;
+    }
+
+    case "typescript": {
+      const headerStr = headerEntries
+        .map(([k, v]) => `    "${k}": "${v}"`)
+        .join(",\n");
+      const headersPart = headerStr
+        ? `  headers: {\n${headerStr}\n  },`
+        : "";
+      const bodyPart = hasBody
+        ? `\n  body: JSON.stringify(${JSON.stringify(bodyValue, null, 2)})`
+        : "";
+
+      return `const options: RequestInit = {
+  method: '${method}'${headersPart ? `,\n${headersPart}` : ""}${bodyPart}
+};
+
+fetch('${url}', options)
+  .then((response: Response) => response.json())
+  .then((data: any) => console.log(data))
+  .catch((err: Error) => console.error(err));`;
+    }
+
+    case "python": {
+      const headerStr = headerEntries
+        .map(([k, v]) => `    "${k}": "${v}"`)
+        .join(",\n");
+      const headersPart = headerStr ? `    headers={\n${headerStr}\n    },\n` : "";
+      const bodyPart = hasBody
+        ? `    json=${JSON.stringify(bodyValue, null, 2)},\n`
+        : "";
+
       return `import requests
 
 response = requests.${method.toLowerCase()}( 
-    "${url}",
-    headers={
-${headerString}
-    }${bodyString}
-)${bodyVar}`;
+    '${url}',
+${headersPart}${bodyPart})
+print(response.json())`;
+    }
 
-    case "curl":
-      return `curl -X ${method} "${url}" \\
-${headerString}${bodyString ? ` \\` : ""}${bodyString}`;
+    case "curl": {
+      const headerParts = headerEntries.map(([k, v]) => `  -H "${k}: ${v}"`);
+      const bodyPart = hasBody
+        ? `  -d '${JSON.stringify(bodyValue)}'`
+        : "";
 
-    case "shell":
-      return `curl -X ${method} "${url}" \\\n${headerString}${bodyString}`;
+      return `curl -X ${method} '${url}' \\
+${headerParts.join(" \\\n")}${bodyPart ? ` \\\n${bodyPart}` : ""}`;
+    }
 
-    case "java":
-      return `CloseableHttpClient httpClient = HttpClients.createDefault();
-Http${method.charAt(0) + method.slice(1).toLowerCase()} request = new Http${
-        method.charAt(0) + method.slice(1).toLowerCase()
-      }("${url}");
+    case "shell": {
+      const headerParts = headerEntries.map(([k, v]) => `  -H "${k}: ${v}"`);
+      const bodyPart = hasBody
+        ? `  -d '${JSON.stringify(bodyValue)}'`
+        : "";
 
-${headerString}
+      return `curl -X ${method} '${url}' \\
+${headerParts.join(" \\\n")}${bodyPart ? ` \\\n${bodyPart}` : ""}`;
+    }
 
-CloseableHttpResponse response = httpClient.execute(request);`;
+    case "java": {
+      const headerParts = headerEntries
+        .map(([k, v]) => `      .header("${k}", "${v}")`)
+        .join("\n");
+      const bodyPart = hasBody
+        ? `      .body(JSON.stringify(${JSON.stringify(bodyValue)}))`
+        : "";
 
-    case "swift":
+      return `import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.URI;
+
+HttpClient client = HttpClient.newHttpClient();
+HttpRequest request = HttpRequest.newBuilder()
+      .uri(URI.create("${url}"))
+      .method("${method}", ${bodyPart ? `HttpRequest.BodyPublishers.ofString(${JSON.stringify(JSON.stringify(bodyValue))})` : "HttpRequest.BodyPublishers.noBody()"})
+${headerParts}
+
+HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());`;
+    }
+
+    case "swift": {
+      const headerStr = headerEntries
+        .map(([k, v]) => `    "${k}": "${v}"`)
+        .join(",\n");
+      const headersPart = headerStr ? `    ${headerStr}\n  ]` : "  ]";
+      const bodyPart = hasBody
+        ? `\n    request.httpBody = try? JSONSerialization.data(withJSONObject: ${JSON.stringify(bodyValue)})`
+        : "";
+
       return `import Foundation
 
 let url = URL(string: "${url}")!
 var request = URLRequest(url: url)
 request.httpMethod = "${method}"
+request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 request.allHTTPHeaderFields = [
-${headerString}
-]${bodyString}${bodyVar}
+${headersPart}${bodyPart}
 
 let task = URLSession.shared.dataTask(with: request) { data, response, error in
-    // Handle response
+    if let data = data {
+        let json = try? JSONSerialization.jsonObject(with: data)
+        print(json ?? "No data")
+    }
 }
 task.resume()`;
+    }
 
     case "go": {
-      const jsonImport = bodyVar
-        ? 'import (\n    "bytes"\n    "encoding/json"\n    "net/http"\n)'
-        : 'import "net/http"';
-      const reqLine = bodyVar
-        ? bodyString
-        : `req, _ := http.NewRequest("${method}", "${url}", nil)`;
-      return `${jsonImport}
+      const headerParts = headerEntries
+        .map(([k, v]) => `    req.Header.Set("${k}", "${v}")`)
+        .join("\n");
+      const bodyPart = hasBody
+        ? `\n    jsonBody, _ := json.Marshal(${JSON.stringify(bodyValue)})\n    req, _ = http.NewRequest("${method}", "${url}", bytes.NewBuffer(jsonBody))`
+        : `\n    req, _ := http.NewRequest("${method}", "${url}", nil)`;
 
-${reqLine}${bodyVar}
-${headerString}
+      return `package main
+
+import (
+    "bytes"
+    "encoding/json"
+    "net/http"
+)
+
+${bodyPart}
+${headerParts}
 
 client := &http.Client{}
 resp, err := client.Do(req)
 if err != nil {
-    // Handle error
+    panic(err)
 }
 defer resp.Body.Close()`;
     }
 
     default:
-      return "";
-  }
-}
-
-// requestBody에서 실제 값을 추출하는 함수 (재귀)
-function extractRequestBodyValue(field: any): any {
-  if (!field) return undefined;
-
-  // SchemaField 타입인 경우
-  if (field.schemaType) {
-    const schemaType = field.schemaType;
-
-    if (schemaType.kind === "primitive") {
-      // Primitive 타입: value가 있으면 사용, 없으면 mockExpression 또는 기본값
-      return (
-        field.value || field.mockExpression || getDefaultValue(schemaType.type)
-      );
-    } else if (schemaType.kind === "object") {
-      // Object 타입: properties를 재귀적으로 처리
-      const obj: any = {};
-      if (schemaType.properties) {
-        schemaType.properties.forEach((prop: any) => {
-          const value = extractRequestBodyValue(prop);
-          if (value !== undefined) {
-            obj[prop.key] = value;
-          }
-        });
-      }
-      return Object.keys(obj).length > 0 ? obj : undefined;
-    } else if (schemaType.kind === "array") {
-      // Array 타입: items를 재귀적으로 처리
-      const itemValue = extractRequestBodyValue({
-        schemaType: schemaType.items,
-      });
-      return itemValue !== undefined ? [itemValue] : undefined;
-    } else if (schemaType.kind === "ref") {
-      // Ref 타입: 스키마 참조이므로 기본값 반환
-      return undefined;
-    }
-  }
-
-  // 일반 객체인 경우 (fields 배열)
-  if (Array.isArray(field.fields)) {
-    const obj: any = {};
-    field.fields.forEach((f: any) => {
-      const value = extractRequestBodyValue(f);
-      if (value !== undefined) {
-        obj[f.key] = value;
-      }
-    });
-    return Object.keys(obj).length > 0 ? obj : undefined;
-  }
-
-  return undefined;
-}
-
-function getDefaultValue(type: string): any {
-  switch (type) {
-    case "string":
-      return "";
-    case "integer":
-    case "number":
-      return 0;
-    case "boolean":
-      return false;
-    case "file":
-      return undefined;
-    default:
-      return "";
+      return `// ${lang} 언어는 아직 지원되지 않습니다.`;
   }
 }

--- a/front/src/features/spec/types/schema.types.ts
+++ b/front/src/features/spec/types/schema.types.ts
@@ -58,6 +58,9 @@ export interface RequestBody {
   fields?: SchemaField[];
   description?: string;
   required?: boolean;
+  // Root schema type for json/xml (object, array, primitive)
+  // If not specified, defaults to object (for backward compatibility)
+  rootSchemaType?: SchemaType;
 }
 
 // ========== Response Body ==========


### PR DESCRIPTION

## 📌 Summary

JSON/XML 타입의 requestBody에서 Array, primitive, schema reference를 root type으로 지원하고, 코드 스니펫 생성 로직을 재작성했습니다. 또한 tags를 자동으로 대문자로 변환하도록 개선했습니다.

---

## ✅ Type of Change

- [x] ✨ Feature (new functionality)
- [x] 🐞 Bug fix (non-breaking fix)
- [x] ♻️ Refactor (code restructuring with no behavior change)
- [x] 📝 Documentation (updates to README or other docs)

---

## 🧠 Description

### 주요 변경사항

1. **Array Root Type 지원**
   - JSON/XML 타입의 requestBody에서 object뿐만 아니라 array, primitive, schema reference를 root type으로 사용 가능
   - Array items에 schema reference 지원
   - 스키마 조회 로직 추가로 properties 자동 표시

2. **코드 스니펫 생성 재작성**
   - `CodeSnippetPanel`을 완전히 재작성하여 전체 스펙 정보를 prop으로 받도록 변경
   - `openapi-snippet` 라이브러리 의존성 제거, 직접 스니펫 생성
   - Array items의 ref 스키마 조회 및 기본값 생성 개선
   - `[null]` 또는 body가 없는 문제 해결

3. **테스트 폼 개선**
   - `RequestBodyForm`에서 Array 타입의 rootSchemaType 처리
   - `TestRequestPanel`에서 Array items의 ref 스키마 조회
   - object schema의 properties를 기반으로 기본값 생성

4. **UI/UX 개선**
   - object 타입에서 스키마 선택 시 필드 편집 비활성화 (form-data와 동일한 동작)
   - Schema 참조 중복 표시 문제 해결
   - 스키마 선택 시 properties 자동 표시

5. **Tags 자동 대문자 변환**
   - API 생성/수정 시 tags를 자동으로 대문자로 변환
   - YAML import 시에도 tags 대문자 변환
   - 태그 일관성 향상

---

## 🔍 Changes

- [x] Service / Logic
- [x] Frontend / UI
- [x] Documentation

**변경된 파일:**

**Backend:**
- `backend/src/main/java/kr/co/ouroboros/core/rest/spec/service/RestApiSpecServiceimpl.java`
  - Tags 대문자 변환 로직 추가 (생성, 수정, import)

**Frontend:**
- `front/src/features/spec/types/schema.types.ts`
  - `RequestBody`에 `rootSchemaType` 필드 추가
- `front/src/features/spec/components/ApiRequestCard.tsx`
  - Root Type 선택 UI 추가
  - object 타입에서 스키마 선택 시 필드 편집 비활성화
  - Schema 참조 중복 표시 제거
- `front/src/features/spec/components/CodeSnippetPanel.tsx`
  - 완전 재작성: 전체 스펙 정보를 prop으로 받도록 변경
  - Array items의 ref 스키마 조회 및 기본값 생성
- `front/src/features/spec/components/ApiEditorLayout.tsx`
  - Array items의 ref 스키마 조회 로직 추가
  - `currentSpec` state 추가 (CodeSnippetPanel에 전달)
- `front/src/features/spec/utils/schemaConverter.ts`
  - `rootSchemaType` 지원 추가
- `front/src/features/testing/components/TestRequestPanel.tsx`
  - Array items의 ref 스키마 조회 로직 추가
- `front/src/features/testing/components/RequestBodyForm.tsx`
  - Array 타입의 rootSchemaType 처리
  - object schema의 properties 기반 기본값 생성

---

## 🧾 Related Issues

> Closes 없음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * API 요청 바디에 루트 타입 선택기 추가 (객체, 배열, 기본 타입, 참조)
  * 코드 스니펫 생성 기능 개선

* **버그 수정**
  * 배열 항목 스키마 참조 처리 강화
  * 스키마 참조 해석 실패 시 경고 로깅

* **리팩토링**
  * 코드 스니펫 생성 로직 재작성
  * API 스펙 데이터 처리 최적화
  * 태그 정규화 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->