### PR TITLE
[FIX] WebSocket API 명세 관리 개선: 중복 검증, 패키지명 정제, sync 안정성 강화

### DIFF
--- a/backend/src/main/java/kr/co/ouroboros/core/global/spec/SpecValidationUtil.java
+++ b/backend/src/main/java/kr/co/ouroboros/core/global/spec/SpecValidationUtil.java
@@ -1,0 +1,136 @@
+package kr.co.ouroboros.core.global.spec;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Utility class for validating API specification fields.
+ * <p>
+ * Provides validation methods for common specification constraints
+ * such as Korean character detection in paths and entrypoints,
+ * and normalization methods for tags.
+ *
+ * @since 0.1.0
+ */
+public class SpecValidationUtil {
+
+    /**
+     * Validates that a path or entrypoint does not contain Korean characters.
+     * <p>
+     * Throws {@link IllegalArgumentException} if Korean characters are detected.
+     *
+     * @param value the value to validate
+     * @param fieldName the name of the field being validated (for error messages)
+     * @throws IllegalArgumentException if the value contains Korean characters
+     */
+    public static void validateNoKorean(String value, String fieldName) {
+        if (value != null && containsKorean(value)) {
+            throw new IllegalArgumentException(
+                    fieldName + " cannot contain Korean characters: " + value
+            );
+        }
+    }
+
+    /**
+     * Validates that a name is a simple class name, not a package-qualified name.
+     * <p>
+     * Throws {@link IllegalArgumentException} if the name contains a dot (.) character,
+     * indicating it is a fully qualified package name.
+     *
+     * @param value the value to validate
+     * @param fieldName the name of the field being validated (for error messages)
+     * @throws IllegalArgumentException if the value contains a dot (package separator)
+     */
+    public static void validateSimpleClassName(String value, String fieldName) {
+        if (value != null && value.contains(".")) {
+            throw new IllegalArgumentException(
+                    fieldName + " must be a simple class name, not a package-qualified name: " + value
+            );
+        }
+    }
+
+    /**
+     * Validates that all names in a list are simple class names.
+     * <p>
+     * Throws {@link IllegalArgumentException} if any name contains a dot (.) character.
+     *
+     * @param values the list of values to validate
+     * @param fieldName the name of the field being validated (for error messages)
+     * @throws IllegalArgumentException if any value contains a dot (package separator)
+     */
+    public static void validateSimpleClassNames(List<String> values, String fieldName) {
+        if (values != null) {
+            for (String value : values) {
+                validateSimpleClassName(value, fieldName);
+            }
+        }
+    }
+
+    /**
+     * Normalizes REST API tags to uppercase.
+     * <p>
+     * Converts all tag strings in the list to uppercase.
+     *
+     * @param tags the list of tag strings to normalize
+     * @return normalized list with uppercase tags, or null if input is null
+     */
+    public static List<String> normalizeRestTags(List<String> tags) {
+        if (tags == null) {
+            return null;
+        }
+        return tags.stream()
+                .map(tag -> tag != null ? tag.toUpperCase() : null)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Normalizes WebSocket/AsyncAPI tags to uppercase.
+     * <p>
+     * Converts all tag name fields in the list to uppercase.
+     * Each tag is a Map with a "name" field.
+     *
+     * @param tags the list of tag maps to normalize
+     * @return normalized list with uppercase tag names, or null if input is null
+     */
+    public static List<Map<String, String>> normalizeWebSocketTags(List<Map<String, String>> tags) {
+        if (tags == null) {
+            return null;
+        }
+        return tags.stream()
+                .map(tag -> {
+                    if (tag != null && tag.containsKey("name")) {
+                        Map<String, String> normalizedTag = new java.util.LinkedHashMap<>(tag);
+                        String name = normalizedTag.get("name");
+                        if (name != null) {
+                            normalizedTag.put("name", name.toUpperCase());
+                        }
+                        return normalizedTag;
+                    }
+                    return tag;
+                })
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Checks if a string contains Korean characters.
+     * <p>
+     * Detects:
+     * <ul>
+     *   <li>Complete Korean characters (가-힣): U+AC00 to U+D7A3</li>
+     *   <li>Hangul Jamo (초성/중성/종성): U+1100 to U+11FF</li>
+     *   <li>Hangul Compatibility Jamo (호환 자모): U+3130 to U+318F</li>
+     * </ul>
+     *
+     * @param str the string to check
+     * @return true if Korean characters are found, false otherwise
+     */
+    private static boolean containsKorean(String str) {
+        return str.chars().anyMatch(ch ->
+                (ch >= 0xAC00 && ch <= 0xD7A3) ||  // 가-힣 (Complete Korean characters)
+                (ch >= 0x1100 && ch <= 0x11FF) ||  // Hangul Jamo (초성/중성/종성)
+                (ch >= 0x3130 && ch <= 0x318F)     // Hangul Compatibility Jamo (호환 자모)
+        );
+    }
+}
+

--- a/backend/src/main/java/kr/co/ouroboros/core/rest/handler/helper/EndpointDiffHelper.java
+++ b/backend/src/main/java/kr/co/ouroboros/core/rest/handler/helper/EndpointDiffHelper.java
@@ -62,6 +62,10 @@ public final class EndpointDiffHelper {
                     op.setXOuroborosId(UUID.randomUUID().toString());
                     log.debug("Generated x-ouroboros-id for {} {}: {}", method, url, op.getXOuroborosId());
                 }
+                // Normalize tags to uppercase
+                if (op.getTags() != null) {
+                    op.setTags(kr.co.ouroboros.core.global.spec.SpecValidationUtil.normalizeRestTags(op.getTags()));
+                }
                 op.setXOuroborosDiff("endpoint");
                 op.setXOuroborosTag("none");
                 
@@ -431,6 +435,11 @@ public final class EndpointDiffHelper {
         if (scanOp.getXOuroborosId() == null) {
             scanOp.setXOuroborosId(UUID.randomUUID().toString());
             log.debug("Generated x-ouroboros-id for {} {}: {}", method, url, scanOp.getXOuroborosId());
+        }
+
+        // Normalize tags to uppercase
+        if (scanOp.getTags() != null) {
+            scanOp.setTags(kr.co.ouroboros.core.global.spec.SpecValidationUtil.normalizeRestTags(scanOp.getTags()));
         }
 
         setOperationByMethod(pathItem, method, scanOp);

--- a/backend/src/main/java/kr/co/ouroboros/core/rest/handler/pipeline/RestSpecSyncPipeline.java
+++ b/backend/src/main/java/kr/co/ouroboros/core/rest/handler/pipeline/RestSpecSyncPipeline.java
@@ -59,6 +59,10 @@ public class RestSpecSyncPipeline implements SpecSyncPipeline {
                             operationByMethod.setXOuroborosId(java.util.UUID.randomUUID().toString());
                             log.debug("Generated x-ouroboros-id for {} {}: {}", httpMethod, url, operationByMethod.getXOuroborosId());
                         }
+                        // Normalize tags to uppercase
+                        if (operationByMethod.getTags() != null) {
+                            operationByMethod.setTags(kr.co.ouroboros.core.global.spec.SpecValidationUtil.normalizeRestTags(operationByMethod.getTags()));
+                        }
                         operationByMethod.setXOuroborosDiff("endpoint");
                         operationByMethod.setXOuroborosTag("none");
                     }

--- a/backend/src/main/java/kr/co/ouroboros/core/rest/spec/service/RestApiSpecServiceimpl.java
+++ b/backend/src/main/java/kr/co/ouroboros/core/rest/spec/service/RestApiSpecServiceimpl.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.co.ouroboros.core.global.Protocol;
 import kr.co.ouroboros.core.global.manager.OuroApiSpecManager;
+import kr.co.ouroboros.core.global.spec.SpecValidationUtil;
 import kr.co.ouroboros.core.rest.common.yaml.RestApiYamlParser;
 import kr.co.ouroboros.core.rest.handler.helper.RequestDiffHelper;
 import kr.co.ouroboros.core.rest.mock.model.EndpointMeta;
@@ -68,6 +69,9 @@ public class RestApiSpecServiceimpl implements RestApiSpecService {
     public RestApiSpecResponse createRestApiSpec(CreateRestApiRequest request) throws Exception {
         lock.writeLock().lock();
         try {
+            // Validate path does not contain Korean characters
+            SpecValidationUtil.validateNoKorean(request.getPath(), "Path");
+
             // Generate UUID if not provided
             String id = request.getId() != null ? request.getId() : UUID.randomUUID().toString();
 
@@ -264,6 +268,11 @@ public class RestApiSpecServiceimpl implements RestApiSpecService {
 
             if (operation == null) {
                 throw new IllegalArgumentException("REST API specification with ID '" + id + "' not found");
+            }
+
+            // Validate path does not contain Korean characters if path is being updated
+            if (request.getPath() != null) {
+                SpecValidationUtil.validateNoKorean(request.getPath(), "Path");
             }
 
             // Determine final path and method

--- a/backend/src/main/java/kr/co/ouroboros/core/websocket/handler/pipeline/WebSocketSpecSyncPipeline.java
+++ b/backend/src/main/java/kr/co/ouroboros/core/websocket/handler/pipeline/WebSocketSpecSyncPipeline.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.UUID;
 import kr.co.ouroboros.core.global.handler.SpecSyncPipeline;
 import kr.co.ouroboros.core.global.spec.OuroApiSpec;
+import kr.co.ouroboros.core.global.spec.SpecValidationUtil;
 import kr.co.ouroboros.core.websocket.common.dto.MessageReference;
 import kr.co.ouroboros.core.websocket.common.dto.Operation;
 import kr.co.ouroboros.core.websocket.common.dto.OuroWebSocketApiSpec;
@@ -47,6 +48,10 @@ public class WebSocketSpecSyncPipeline implements SpecSyncPipeline {
                     // Generate x-ouroboros-id if not present
                     if (operation.getXOuroborosId() == null) {
                         operation.setXOuroborosId(java.util.UUID.randomUUID().toString());
+                    }
+                    // Normalize tags to uppercase
+                    if (operation.getTags() != null) {
+                        operation.setTags(SpecValidationUtil.normalizeWebSocketTags(operation.getTags()));
                     }
                     operation.setXOuroborosDiff("channel");
                     operation.setXOuroborosProgress("none");
@@ -91,6 +96,10 @@ public class WebSocketSpecSyncPipeline implements SpecSyncPipeline {
             
             // 파일에 없는 경우 추가
             if(!fileChannelNameOperationMap.containsKey(channelRef)){
+                // Normalize tags to uppercase
+                if (scanOp.getTags() != null) {
+                    scanOp.setTags(SpecValidationUtil.normalizeWebSocketTags(scanOp.getTags()));
+                }
 
                 scanOp.setXOuroborosDiff("channel");
                 scanOp.setXOuroborosId(UUID.randomUUID().toString());

--- a/backend/src/main/java/kr/co/ouroboros/core/websocket/spec/service/WebSocketServerManager.java
+++ b/backend/src/main/java/kr/co/ouroboros/core/websocket/spec/service/WebSocketServerManager.java
@@ -1,5 +1,6 @@
 package kr.co.ouroboros.core.websocket.spec.service;
 
+import kr.co.ouroboros.core.global.spec.SpecValidationUtil;
 import kr.co.ouroboros.core.websocket.common.yaml.WebSocketYamlParser;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -34,6 +35,9 @@ public class WebSocketServerManager {
      * @param pathname WebSocket pathname (entry point)
      */
     public void ensureServerExists(Map<String, Object> asyncApiDoc, String protocol, String pathname) {
+        // Validate pathname does not contain Korean characters
+        SpecValidationUtil.validateNoKorean(pathname, "Pathname");
+
         // Generate server name from protocol + pathname
         String serverName = generateServerName(protocol, pathname);
 

--- a/backend/src/main/java/kr/co/ouroboros/core/websocket/spec/util/RefCleanupUtil.java
+++ b/backend/src/main/java/kr/co/ouroboros/core/websocket/spec/util/RefCleanupUtil.java
@@ -1,0 +1,114 @@
+package kr.co.ouroboros.core.websocket.spec.util;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Utility class for cleaning up package names from references in WebSocket specifications.
+ * <p>
+ * Provides methods to remove package prefixes and full paths from $ref values,
+ * returning only simple class names for cleaner API responses.
+ *
+ * @since 0.1.0
+ */
+public class RefCleanupUtil {
+
+    /**
+     * Recursively removes package names from all $ref values in a map.
+     * <p>
+     * Converts references like "#/components/messages/com.example.Message" to "Message".
+     * Creates a deep copy to avoid modifying the original map.
+     *
+     * @param map the map to process
+     * @return a new map with cleaned $ref values
+     */
+    @SuppressWarnings("unchecked")
+    public static Map<String, Object> cleanupPackageNamesInRefs(Map<String, Object> map) {
+        if (map == null) {
+            return null;
+        }
+
+        Map<String, Object> cleaned = new LinkedHashMap<>();
+        for (Map.Entry<String, Object> entry : map.entrySet()) {
+            String key = entry.getKey();
+            Object value = entry.getValue();
+
+            if ("$ref".equals(key) && value instanceof String) {
+                // Clean package name from $ref value
+                String ref = (String) value;
+                cleaned.put(key, cleanRefValue(ref));
+            } else if (value instanceof Map) {
+                // Recursively clean nested maps
+                cleaned.put(key, cleanupPackageNamesInRefs((Map<String, Object>) value));
+            } else if (value instanceof List) {
+                // Recursively clean lists
+                List<Object> list = (List<Object>) value;
+                List<Object> cleanedList = new ArrayList<>();
+                for (Object item : list) {
+                    if (item instanceof Map) {
+                        cleanedList.add(cleanupPackageNamesInRefs((Map<String, Object>) item));
+                    } else {
+                        cleanedList.add(item);
+                    }
+                }
+                cleaned.put(key, cleanedList);
+            } else {
+                cleaned.put(key, value);
+            }
+        }
+        return cleaned;
+    }
+
+    /**
+     * Cleans a single $ref value by removing prefix and package names, returning only the class name.
+     * <p>
+     * Examples:
+     * <ul>
+     *   <li>"#/components/schemas/com.example.User" -> "User"</li>
+     *   <li>"#/components/messages/com.example.Message" -> "Message"</li>
+     *   <li>"#/channels/channelName/messages/com.example.Msg" -> "Msg"</li>
+     * </ul>
+     *
+     * @param ref the $ref value to clean
+     * @return simple class name without prefix or package
+     */
+    public static String cleanRefValue(String ref) {
+        if (ref == null || !ref.contains("/")) {
+            return ref;
+        }
+
+        // Get the last part after the final slash
+        int lastSlashIndex = ref.lastIndexOf('/');
+        if (lastSlashIndex == -1) {
+            return ref;
+        }
+
+        String name = ref.substring(lastSlashIndex + 1);
+
+        // Extract class name from fully qualified name (removes package if present)
+        return extractClassNameFromFullName(name);
+    }
+
+    /**
+     * Extracts the simple class name from a package-qualified name.
+     * <p>
+     * Example: "com.c102.ourotest.dto.User" -> "User"
+     *
+     * @param fullName the package-qualified name
+     * @return the simple class name, or the original string if no '.' is present
+     */
+    public static String extractClassNameFromFullName(String fullName) {
+        if (fullName == null || fullName.isEmpty()) {
+            return fullName;
+        }
+
+        int lastDotIndex = fullName.lastIndexOf('.');
+        if (lastDotIndex == -1) {
+            return fullName;
+        }
+
+        return fullName.substring(lastDotIndex + 1);
+    }
+}


### PR DESCRIPTION
  ## 📌 Summary
  WebSocket API 명세 관리 개선: 중복 검증, 패키지명 정제, sync 안정성 강화

  ---

  ## ✅ Type of Change
  - [x] ✨ Feature (new functionality)
  - [x] 🐞 Bug fix (non-breaking fix)
  - [x] ♻️ Refactor (code restructuring with no behavior change)

  ---

  ## 🧠 Description
  WebSocket API 명세 관리 시스템의 안정성과 사용성을 개선했습니다.

  ### 주요 개선 사항
  1. **Operation 중복 검증**: 같은 entrypoint + action + channel 조합으로 중복 생성되는 것을 방지
  2. **입력 검증 강화**: 메시지 필드에 full package name이 입력되는 것을 차단 (클래스명만 허용)
  3. **응답 정제**: 모든 CRUD 응답에서 패키지명을 제거하고 클래스명만 반환
  4. **Sync 안정성**: cache/file 간 servers 자동 동기화 및 entrypoint 자동 반영
  5. **코드 중복 제거**: 공통 유틸리티 클래스(`RefCleanupUtil`) 생성

  ---

  ## 🔍 Changes
  - [x] Service / Logic
  - [x] Config / Infrastructure
  - [x] Documentation

  ### 상세 변경 사항

  #### 1. Operation 중복 검증 (`WebSocketOperationServiceImpl`)
  - `validateNoDuplicateOperation()` 메서드 추가
  - entrypoint + action + channel + replyChannel 조합으로 중복 검증
  - create/update 시 자동 검증, update 시 자기 자신 제외

  #### 2. 입력 검증 강화 (`SpecValidationUtil`)
  - `validateSimpleClassName()`, `validateSimpleClassNames()` 메서드 추가
  - create/update 요청 시 메시지 필드 검증
  - full package name (예: `com.example.User`) 차단, 클래스명만 허용

  #### 3. 응답 패키지명 제거
  **공통 유틸리티 생성**
  - `RefCleanupUtil` 클래스 생성
    - `cleanupPackageNamesInRefs()`: 재귀적으로 모든 $ref 정제
    - `cleanRefValue()`: prefix + package 제거 (예: `#/components/schemas/com.example.User` → `User`)
    - `extractClassNameFromFullName()`: 클래스명 추출

  **적용 서비스**
  - `WebSocketOperationServiceImpl`: operation CRUD 응답
  - `WebSocketChannelServiceImpl`: channel 조회 응답
  - `WebSocketSchemaServiceImpl`: schema CRUD 응답
  - `WebSocketMessageServiceImpl`: message CRUD 응답

  **정제 대상**
  - `$ref` 값: `#/components/schemas/com.example.User` → `User`
  - 이름 필드: `messageName`, `schemaName`, `channelName` 등
  - messages 키: `com.example.Message` → `Message`

  #### 4. Sync 안정성 개선 (`WebSocketOperationServiceImpl.syncToFile`)
  - `syncServersFromCache()` 메서드 추가
  - fileDoc에 servers 없으면 cacheDoc에서 복사
  - cacheDoc에도 없으면 기본 서버 생성 (`ws:///ws`)
  - entrypoint 추출 우선순위: fileDoc > cacheDoc > 기본값(`/ws`)
  - Step 번호 정리 (1~13)

  ---

  ## 🧾 Related Issues
  WebSocket API 명세 관리 시 발생하던 중복 생성, 패키지명 노출, sync 실패 문제 해결

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * API 사양 검증 강화: 부적절한 문자 및 이름 형식 검사 추가
  * 태그 정규화: REST 및 WebSocket 태그 자동 대문자 변환
  * 참조 정리: 스키마 및 메시지의 패키지 이름 자동 제거

* **버그 수정**
  * WebSocket 작업 중복 방지 메커니즘 구현
  * 스키마 및 메시지 참조 정확성 향상
  * 서버 동기화 안정성 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->