### PR TITLE
[FIX] enable 설정 false하면 안되던거 고침

### DIFF
--- a/backend/src/main/java/kr/co/ouroboros/core/rest/tryit/config/MethodTracingConfig.java
+++ b/backend/src/main/java/kr/co/ouroboros/core/rest/tryit/config/MethodTracingConfig.java
@@ -14,6 +14,7 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 
@@ -43,13 +44,16 @@ import java.util.Set;
  *   <li>Always excludes kr.co.ouroboros.* SDK classes</li>
  * </ul>
  * <p>
- * Method tracing is disabled by default. To enable it, set {@code ouroboros.method-tracing.enabled=true}
+ * <b>Activation:</b>
+ * This configuration is enabled by default. To disable, set {@code ouroboros.enabled=false}.
+ * Method tracing is disabled by default within this configuration. To enable it, set {@code ouroboros.method-tracing.enabled=true}
  * and configure at least one allowed package. If no allowed packages are configured, method tracing is disabled.
  *
  * @author Ouroboros Team
  * @since 0.0.1
  */
 @AutoConfiguration
+@ConditionalOnProperty(prefix = "ouroboros", name = "enabled", havingValue = "true", matchIfMissing = true)
 @EnableConfigurationProperties(MethodTracingProperties.class)
 @ConditionalOnClass(Advisor.class)
 public class MethodTracingConfig {

--- a/backend/src/main/java/kr/co/ouroboros/core/rest/tryit/config/TraceStorageConfig.java
+++ b/backend/src/main/java/kr/co/ouroboros/core/rest/tryit/config/TraceStorageConfig.java
@@ -33,6 +33,9 @@ import org.springframework.context.annotation.Primary;
  *   <li>{@link Sampler} - TryOnlySampler to sample only Try requests</li>
  *   <li>{@link SpanProcessor} - TempoTrySpanProcessor or InMemoryTrySpanProcessor based on Tempo enabled status</li>
  * </ul>
+ * <p>
+ * <b>Activation:</b>
+ * This configuration is enabled by default. To disable, set {@code ouroboros.enabled=false}.
  *
  * @author Ouroboros Team
  * @since 0.0.1
@@ -40,6 +43,7 @@ import org.springframework.context.annotation.Primary;
 @Slf4j
 @AutoConfiguration
 @AutoConfigureBefore(OpenTelemetryTracingAutoConfiguration.class)
+@ConditionalOnProperty(prefix = "ouroboros", name = "enabled", havingValue = "true", matchIfMissing = true)
 @EnableConfigurationProperties(TempoProperties.class)
 public class TraceStorageConfig {
     


### PR DESCRIPTION
  ## 📌 Summary
  `ouroboros.enabled=false` 설정 시 애플리케이션이 정상적으로 실행되도록 수정

  ---

  ## ✅ Type of Change
  - [x] 🐞 Bug fix (non-breaking fix)

  ---

  ## 🧠 Description
  `ouroboros.enabled=false`로 설정했을 때, Try 관련 설정 클래스(`TraceStorageConfig`, `MethodTracingConfig`)가
  여전히 로드되어 `TraceStorage` 빈을 찾지 못하는 에러가 발생했습니다.

  **문제 원인:**
  - `OuroborosAutoConfiguration`에는 `@ConditionalOnProperty`가 있어 컴포넌트 스캔이 비활성화되지만
  - `TraceStorageConfig`와 `MethodTracingConfig`는 독립적인 `@AutoConfiguration`으로 여전히 로드됨
  - `InMemoryTraceStorage` 빈이 생성되지 않아 `TraceStorageConfig.inMemoryTrySpanProcessor()` 메서드가 실패

  **해결 방법:**
  Try 관련 설정 클래스들에 `@ConditionalOnProperty(prefix = "ouroboros", name = "enabled", havingValue = "true",      
  matchIfMissing = true)` 추가

  ---

  ## 🔍 Changes
  - [x] Config / Infrastructure

  **수정된 파일:**
  - `TraceStorageConfig.java` - 조건부 설정 추가
  - `MethodTracingConfig.java` - 조건부 설정 추가

  ---

  ## 🧾 Related Issues
  N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 조건부 구성 활성화를 통해 시스템 기능의 제어 기능을 개선했습니다.
  * 핵심 컴포넌트가 기본값으로 활성화되며, 설정을 통해 커스터마이징할 수 있습니다.
  * 운영 관리자가 구성 속성을 통해 기능 동작을 유연하게 조정할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->