### PR TITLE
[FIX] 초록색 배지 상태의 WebSocket 엔드포인트에서 CONNECT 버튼 활성화

### DIFF
--- a/front/src/features/testing/components/WsTestRequestPanel.tsx
+++ b/front/src/features/testing/components/WsTestRequestPanel.tsx
@@ -58,6 +58,20 @@ export function WsTestRequestPanel() {
     return domain.charAt(0).toUpperCase() + domain.slice(1).toLowerCase();
   };
 
+  // CONNECT 버튼 활성화 여부 계산 (초록색 배지 조건)
+  const isConnectEnabled = useMemo(() => {
+    if (!selectedEndpoint || selectedEndpoint.protocol !== "WebSocket") {
+      return false;
+    }
+    const normalizedProgress = selectedEndpoint.progress?.toLowerCase();
+    const normalizedTag = selectedEndpoint.tag?.toLowerCase();
+    return (
+      normalizedProgress === "completed" ||
+      normalizedProgress === "complete" ||
+      (normalizedTag === "receive" && normalizedProgress === "receive")
+    );
+  }, [selectedEndpoint]);
+
   // 도메인별 구독 경로 계산
   const domainSubscriptionPaths = useMemo(() => {
     if (!selectedEndpoint || selectedEndpoint.protocol !== "WebSocket") {
@@ -611,13 +625,9 @@ export function WsTestRequestPanel() {
             {wsConnectionStatus === "disconnected" ? (
               <button
                 onClick={handleConnect}
-                disabled={
-                  !selectedEndpoint ||
-                  selectedEndpoint.progress?.toLowerCase() !== "completed"
-                }
+                disabled={!isConnectEnabled}
                 className={`flex-1 px-4 py-2 rounded-md transition-all text-sm font-semibold active:translate-y-[1px] focus:outline-none focus-visible:outline-none md:flex-none md:w-auto w-full ${
-                  !selectedEndpoint ||
-                  selectedEndpoint.progress?.toLowerCase() !== "completed"
+                  !isConnectEnabled
                     ? "bg-gray-300 dark:bg-gray-700 text-gray-500 dark:text-gray-400 cursor-not-allowed"
                     : "bg-[#2563EB] hover:bg-[#1E40AF] text-white"
                 }`}


### PR DESCRIPTION
## 📌 Summary
Provide a brief summary of what this PR does and why it’s needed.

> 초록색 배지 상태의 WebSocket 엔드포인트에서 CONNECT 버튼 활성화

---

## ✅ Type of Change
Check all that apply.

- [ ] ✨ Feature (new functionality)
- [x] 🐞 Bug fix (non-breaking fix)
- [ ] ♻️ Refactor (code restructuring with no behavior change)
- [ ] 🧪 Test (adding or updating tests)
- [ ] 📝 Documentation (updates to README or other docs)
- [ ] 🎨 Style (formatting, naming, or lint fixes)
- [ ] 🚀 Performance (improves efficiency or speed)
- [ ] 🔧 Chore (build, CI, dependencies, etc.)

---

## 🧠 Description
Explain the purpose and reasoning behind the changes.

> - 사이드바 배지 색상 조건에 맞춰 CONNECT 버튼 활성화 로직 수정
> - progress가 "completed" 또는 "complete"일 때 CONNECT 버튼 활성화
> - tag가 "receive"이고 progress가 "receive"일 때 CONNECT 버튼 활성화
> - useMemo를 사용하여 isConnectEnabled 계산 성능 개선
---

## 🔍 Changes
Select the components or files affected.

- [ ] Controller / Route
- [ ] Service / Logic
- [ ] Repository / Database
- [x] Frontend / UI
- [ ] Config / Infrastructure
- [ ] Documentation
- [ ] Other: _______

---

## 🧾 Related Issues
Link any related issues or discussions.

> Closes 
